### PR TITLE
Ignore .babelrc in npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc


### PR DESCRIPTION
Inclusion of the babelrc can break projects that don't have all the devDeps that you have included.